### PR TITLE
Allow user to transientInclude the last_read_message

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -111,6 +111,23 @@ class Demo {
     });
   }
 
+  fetchUserConversationsTo(el) {
+    return this.plugin.getUserConversations().then(function (result) {
+      var ul = $(el);
+      ul.textContent = '';
+      console.log(result);
+      result.forEach(function (uc) {
+        var liEl = document.createElement('div');
+        var text = uc.$transient.conversation.title + ': ';
+        if (uc.last_read_message) {
+          text = text + uc.$transient.last_read_message.body;
+        }
+        liEl.textContent = text;
+        ul.appendChild(liEl);
+      });
+    });
+  }
+
   leaveConversation() {
     return this.plugin.leaveConversation(this.conversation);
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -116,6 +116,13 @@
       onclick="demo.fetchConversationsTo('conversation');"
     >Fetch Converstions</button></p>
     <hr/>
+    <h3>Conversation with User last read message</h3>
+    <ul id="user-conversation">
+    </ul>
+    <p><button
+      onclick="demo.fetchUserConversationsTo('user-conversation');"
+    >Fetch User X Converstions</button></p>
+    <hr/>
     <h3>Go to converation</h3>
     <p>
       <label>Conversation ID</label>

--- a/lib/index.js
+++ b/lib/index.js
@@ -128,6 +128,10 @@ export class SkygearChatContainer {
    * UserConversation will transientInclude Conversion and User object for
    * ease of use.
    *
+   * For transientInclude of `last_read_message`, we provided an boolean flag
+   * to include or not. This function will transientInclude the it unless
+   * specified otherwise.
+   *
    * @example
    * const skygearChat = require('skygear-chat');¬
    *
@@ -144,15 +148,52 @@ export class SkygearChatContainer {
    *     console.log('Cannot load conversation list');
    *   });
    *
+   * @param {boolean} includeLastMessage - Transient include the
+   * `last_read_message`, default is true.
    * @return {Promise<[]UserConversation>} - A promise to UserConversation Recrods
    */
-
-  getUserConversations() {
+  getUserConversations(includeLastMessage = true) {
     const query = new skygear.Query(UserConversation);
     query.equalTo('user', skygear.currentUser.id);
     query.transientInclude('user');
     query.transientInclude('conversation');
-    return skygear.publicDB.query(query);
+    return skygear.publicDB.query(query).then(function (result) {
+      if (!includeLastMessage) {
+        return result;
+      }
+      return this._getMessageOfUserConversation(result);
+    }.bind(this));
+  }
+
+  _getMessageOfUserConversation(userConversation) {
+    const messageIDs = _.reduce(userConversation, function (mids, uc) {
+      if (uc.last_read_message) {
+        const mid = skygear.Record.parseID(uc.last_read_message.id)[1];
+        mids.push(mid);
+      }
+      return mids;
+    }, []);
+    return skygear
+      .lambda('chat:get_messages_by_ids', [messageIDs])
+      .then(function (data) {
+        const messagesByID = _.reduce(data.results, function (byID, m) {
+          byID[m._id] = m;
+          return byID;
+        }, {});
+        const ucWithMessage = _.reduce(
+          userConversation,
+          function (withMessage, uc) {
+            if (uc.last_read_message) {
+              uc.updateTransient({
+                last_read_message: messagesByID[uc.last_read_message.id]
+              }, true);
+            }
+            withMessage.push(uc);
+            return withMessage;
+          },
+          []);
+        return ucWithMessage;
+      });
   }
 
   /**
@@ -162,10 +203,16 @@ export class SkygearChatContainer {
    * The UserConversation will transientInclude Conversion and User object
    * for ease of use.
    *
+   * For transientInclude of `last_read_message`, we provided an boolean flag
+   * to include or not. This function will transientInclude the it unless
+   * specified otherwise.
+   *
    * @param {string} conversation - Conversation
+   * @param {boolean} includeLastMessage - Transient include the
+   * `last_read_message`, default is true.
    * @return {Promise<UserConversation>} - A promise to UserConversation Recrod
    */
-  getUserConversation(conversation) {
+  getUserConversation(conversation, includeLastMessage = true) {
     const query = new skygear.Query(UserConversation);
     query.equalTo('user', skygear.currentUser.id);
     query.equalTo('conversation', new skygear.Reference(conversation.id));
@@ -173,10 +220,15 @@ export class SkygearChatContainer {
     query.transientInclude('conversation');
     return skygear.publicDB.query(query).then(function (records) {
       if (records.length > 0) {
-        return records[0];
+        if (!includeLastMessage) {
+          return records[0];
+        }
+        return this._getMessageOfUserConversation(records).then(function (ucs) {
+          return ucs[0];
+        });
       }
       throw new Error('no conversation found');
-    });
+    }.bind(this));
   }
 
   /**


### PR DESCRIPTION
Since the implementation required another network request, we provide a flag
to turn it off. It allow developer to have a faster response if no last read
message is needed.

connects SkygearIO/chat#76