### PR TITLE
fix API doc & getMessages() return val

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -362,7 +362,7 @@ export class SkygearChatContainer {
    * purpose
    * @param {File} asset - File object to be saves as attachment of this
    * message
-   * @return {Promise<Conversation>} - A promise to save result
+   * @return {Promise<Message>} - A promise to save result
    */
   createMessage(conversation, body, metadata, asset) {
     const message = new Message();
@@ -438,7 +438,7 @@ export class SkygearChatContainer {
    * @param {number} [limit=50] - limit the result set, if it is set to too large, may
    * result in timeout.
    * @param {Date} beforeTime - specific from which time
-   * @return {Promise<int>} - A promise to total count
+   * @return {Promise<[]Message>} - array of Message records
    */
   getMessages(conversation, limit = 50, beforeTime) {
     const conversationID = conversation._id;
@@ -449,7 +449,7 @@ export class SkygearChatContainer {
           return new Message(message_data);
         });
         this.markAsDelivered(data.results);
-        return data;
+        return data.results;
       }.bind(this));
   }
 


### PR DESCRIPTION
Currently `getMessages()` return an object:
```js
{results: []}
```
It should only return the array of Message Records.