### PR TITLE
Remove node v4 and v5 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 node_js:
 - v7
 - v6
-- v5
-- v4
 
 install:
   - npm install skygear@1.1.0


### PR DESCRIPTION
Test for these versions are removed because they are failing while the
new versions have no problem. These versions are also not tested in the
skygear-SDK-JS repo.

connects #76