### PR TITLE
Wrap cloud hooks with SkygearChatCloudContainer

### DIFF
--- a/lib/cloud.js
+++ b/lib/cloud.js
@@ -19,184 +19,185 @@ const skygear = require('skygear');
 const Conversation = skygear.Record.extend('conversation');
 const User = skygear.Record.extend('user');
 const Message = skygear.Record.extend('message');
-const container = new skygearCloud.CloudCodeContainer();
-container.apiKey = skygearCloud.settings.apiKey;
-container.endPoint = skygearCloud.settings.skygearEndpoint + '/';
 
+export class SkygearChatCloudContainer {
+  chatHook(name, func) {
+    skygearCloud.op('chat:' + name + '_hook', function (param, options) {
+      const context = {userId: options.context.user_id};
+      func(param.args, context);
+      return {status: 'ok'};
+    }, {
+      userRequired: true,
+      keyRequired: true
+    });
+  }
 
-function chatHook(name, func) {
-  skygearCloud.op('chat:' + name + '_hook', function (param, options) {
-    const context = {userId: options.context.user_id};
-    func(param.args, context);
-    return {status: 'ok'};
-  }, {
-    userRequired: true,
-    keyRequired: true
-  });
+  /**
+   * After message sent hook.
+   *
+   * This hook will be triggered once a message is sent by an user.
+   *
+   * @example
+   * const chat = require('skygear-chat');
+   * chat.cloud.afterMessageSent((message, conversation, participants, context) => {
+   *   const title = conversation.title;
+   *   const participantIds = participants.map((p) => p._id && p._id != context.userId);
+   *   const currentUser = participants.find((p) => p._id == context.userId);
+   *   let body = '';
+   *   if (message.body) {
+   *     body = currentUser.username + ": " + message.body;
+   *   } else {
+   *     body = currentUser.username + ":" + "sent you a file.";
+   *   }
+   *   const payload = {'gcm': {'notification': {'title': title, 'body': body}}}
+   *   container.push.sendToUser(participantIds, payload);
+   * });
+   *
+   * @param {function(message:Record, conversation:Record, participants:Record[], context:Object)} func - function to be registered
+   */
+
+  afterMessageSent(func) {
+    this.chatHook('after_message_sent', (args, context) => {
+      const message = new Message(args.message);
+      const conversation = new Conversation(args.conversation);
+      const participants = args.participants.map((p) => new User(p));
+      func(message, conversation, participants, context);
+    });
+  }
+
+  /**
+   * After message updated hook.
+   *
+   * This hook will be triggered once a message is updated.
+   *
+   *
+   * @param {function(message:Record, conversation:Record, participants:Record[], context:Object)} func - function to be registered
+   */
+
+  afterMessageUpdated(func) {
+    this.chatHook('after_message_updated', (args, context) => {
+      const message = new Message(args.message);
+      const conversation = new Conversation(args.conversation);
+      const participants = args.participants.map((p) => new User(p));
+      func(message, conversation, participants, context);
+    });
+  }
+
+  /**
+   * After message deleted hook.
+   *
+   * This hook will be triggered once a message is deleted.
+   *
+   * @param {function(message:Record, conversation:Record, participants:Record[], context:Object)} func - function to be registered
+   */
+
+  afterMessageDeleted(func) {
+    this.chatHook('after_message_deleted', (args, context) => {
+      const message = new Message(args.message);
+      const conversation = new Conversation(args.conversation);
+      const participants = args.participants.map((p) => new User(p));
+      func(message, conversation, participants, context);
+    });
+  }
+
+  /**
+   * Typing started hook.
+   *
+   * This hook will be triggered once an user starts typing.
+   *
+   * @param {function(conversation:Record, participants:Record[], event:Object, context: Object)} func - function to be registered
+   */
+
+  typingStarted(func) {
+    this.chatHook('typing_started', (args, context) => {
+      const conversation = new Conversation(args.conversation);
+      const participants = args.participants.map((p) => new User(p));
+      func(conversation, participants, args.events, context);
+    });
+  }
+
+  /**
+   * After conversation created hook.
+   *
+   * This hook will be triggered once a conversation is created.
+   *
+   * @param {function(conversation:Record, participants:Record[], context:Object)} func - function to be registered
+   */
+
+  afterConversationCreated(func) {
+    this.chatHook('after_conversation_created', (args, context) => {
+      const conversation = new Conversation(args.conversation);
+      const participants = args.participants.map((p) => new User(p));
+      func(conversation, participants, context);
+    });
+  }
+
+  /**
+   * After conversation updated hook.
+   *
+   * This hook will be triggered once a conversation is updated.
+   *
+   * @param {function(conversation:Record, participants:Record[], context:Object)} func - function to be registered
+   */
+
+  afterConversationUpdated(func) {
+    this.chatHook('after_conversation_updated', (args, context) => {
+      const conversation = new Conversation(args.conversation);
+      const participants = args.participants.map((p) => new User(p));
+      func(conversation, participants, context);
+    });
+  }
+
+  /**
+   * After conversation deleted hook.
+   *
+   * This hook will be triggered once a conversation is deleted.
+   *
+   * @param {function(conversation:Record, participants:Record[], context:Object)} func - function to be registered
+   */
+
+  afterConversationDeleted(func) {
+    this.chatHook('after_conversation_deleted', (args, context) => {
+      const conversation = new Conversation(args.conversation);
+      const participants = args.participants.map((p) => new User(p));
+      func(conversation, participants, context);
+    });
+  }
+
+  /**
+   * After user added to conversation hook.
+   *
+   * This hook will be triggered once one or more users are added to a conversation.
+   *
+   * @param {function(conversation:Record, participants:Record[], newUsers:Record[], context:Object)} func - function to be registered
+   */
+
+  afterUsersAddedToConversation(func) {
+    this.chatHook('after_users_added_to_conversation', (args, context) => {
+      const conversation = new Conversation(args.conversation);
+      const participants = args.participants.map((p) => new User(p));
+      const newUsers = args.new_users.map((p) => new User(p));
+      func(conversation, participants, newUsers, context);
+    });
+  }
+
+  /**
+   * After user removed from conversation hook.
+   *
+   * This hook will be triggered once one or more users are removed from a conversation.
+   *
+   * @param {function(conversation:Record, participants:Record[], oldUsers:Record[], context:Object)} func - function to be registered
+   */
+
+  afterUsersRemovedFromConversation(func) {
+    this.chatHook('after_users_removed_from_conversation', (args, context) => {
+      const conversation = new Conversation(args.conversation);
+      const participants = args.participants.map((p) => new User(p));
+      const oldUsers = args.old_users.map((p) => new User(p));
+      func(conversation, participants, oldUsers, context);
+    });
+  }
 }
 
-/**
- * After message sent hook.
- *
- * This hook will be triggered once a message is sent by an user.
- *
- * @example
- * const hook = require('skygear-chat/hook');
- * hook.afterMessageSent((message, conversation, participants, context) => {
- *   const title = conversation.title;
- *   const participantIds = participants.map((p) => p._id && p._id != context.userId);
- *   const currentUser = participants.find((p) => p._id == context.userId);
- *   let body = '';
- *   if (message.body) {
- *     body = currentUser.username + ": " + message.body;
- *   } else {
- *     body = currentUser.username + ":" + "sent you a file.";
- *   }
- *   const payload = {'gcm': {'notification': {'title': title, 'body': body}}}
- *   container.push.sendToUser(participantIds, payload);
- * });
- *
- * @param {function(message:Record, conversation:Record, participants:Record[], context:Object)} func - function to be registered
- */
-
-export function afterMessageSent(func) {
-  chatHook('after_message_sent', (args, context) => {
-    const message = new Message(args.message);
-    const conversation = new Conversation(args.conversation);
-    const participants = args.participants.map((p) => new User(p));
-    func(message, conversation, participants, context);
-  });
-}
-
-/**
- * After message updated hook.
- *
- * This hook will be triggered once a message is updated.
- *
- *
- * @param {function(message:Record, conversation:Record, participants:Record[], context:Object)} func - function to be registered
- */
-
-export function afterMessageUpdated(func) {
-  chatHook('after_message_updated', (args, context) => {
-    const message = new Message(args.message);
-    const conversation = new Conversation(args.conversation);
-    const participants = args.participants.map((p) => new User(p));
-    func(message, conversation, participants, context);
-  });
-}
-
-/**
- * After message deleted hook.
- *
- * This hook will be triggered once a message is deleted.
- *
- * @param {function(message:Record, conversation:Record, participants:Record[], context:Object)} func - function to be registered
- */
-
-export function afterMessageDeleted(func) {
-  chatHook('after_message_deleted', (args, context) => {
-    const message = new Message(args.message);
-    const conversation = new Conversation(args.conversation);
-    const participants = args.participants.map((p) => new User(p));
-    func(message, conversation, participants, context);
-  });
-}
-
-/**
- * Typing started hook.
- *
- * This hook will be triggered once an user starts typing.
- *
- * @param {function(conversation:Record, participants:Record[], event:Object, context: Object)} func - function to be registered
- */
-
-export function typingStarted(func) {
-  chatHook('typing_started', (args, context) => {
-    const conversation = new Conversation(args.conversation);
-    const participants = args.participants.map((p) => new User(p));
-    func(conversation, participants, args.events, context);
-  });
-}
-
-/**
- * After conversation created hook.
- *
- * This hook will be triggered once a conversation is created.
- *
- * @param {function(conversation:Record, participants:Record[], context:Object)} func - function to be registered
- */
-
-export function afterConversationCreated(func) {
-  chatHook('after_conversation_created', (args, context) => {
-    const conversation = new Conversation(args.conversation);
-    const participants = args.participants.map((p) => new User(p));
-    func(conversation, participants, context);
-  });
-}
-
-/**
- * After conversation updated hook.
- *
- * This hook will be triggered once a conversation is updated.
- *
- * @param {function(conversation:Record, participants:Record[], context:Object)} func - function to be registered
- */
-
-export function afterConversationUpdated(func) {
-  chatHook('after_conversation_updated', (args, context) => {
-    const conversation = new Conversation(args.conversation);
-    const participants = args.participants.map((p) => new User(p));
-    func(conversation, participants, context);
-  });
-}
-
-/**
- * After conversation deleted hook.
- *
- * This hook will be triggered once a conversation is deleted.
- *
- * @param {function(conversation:Record, participants:Record[], context:Object)} func - function to be registered
- */
-
-export function afterConversationDeleted(func) {
-  chatHook('after_conversation_deleted', (args, context) => {
-    const conversation = new Conversation(args.conversation);
-    const participants = args.participants.map((p) => new User(p));
-    func(conversation, participants, context);
-  });
-}
-
-/**
- * After user added to conversation hook.
- *
- * This hook will be triggered once one or more users are added to a conversation.
- *
- * @param {function(conversation:Record, participants:Record[], newUsers:Record[], context:Object)} func - function to be registered
- */
-
-export function afterUsersAddedToConversation(func) {
-  chatHook('after_users_added_to_conversation', (args, context) => {
-    const conversation = new Conversation(args.conversation);
-    const participants = args.participants.map((p) => new User(p));
-    const newUsers = args.new_users.map((p) => new User(p));
-    func(conversation, participants, newUsers, context);
-  });
-}
-
-/**
- * After user removed from conversation hook.
- *
- * This hook will be triggered once one or more users are removed from a conversation.
- *
- * @param {function(conversation:Record, participants:Record[], oldUsers:Record[], context:Object)} func - function to be registered
- */
-
-export function afterUsersRemovedFromConversation(func) {
-  chatHook('after_users_removed_from_conversation', (args, context) => {
-    const conversation = new Conversation(args.conversation);
-    const participants = args.participants.map((p) => new User(p));
-    const oldUsers = args.old_users.map((p) => new User(p));
-    func(conversation, participants, oldUsers, context);
-  });
-}
+const cloudContainer = new SkygearChatCloudContainer();
+export default cloudContainer;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 import skygearChat from './container.js';
+import cloud from './cloud.js';
 import * as utils from './utils.js';
 
 skygearChat.utils = utils;
+skygearChat.cloud = cloud;
 
 module.exports = skygearChat;


### PR DESCRIPTION
Moving functions in `cloud.js` into `SkygearChatCloudContainer`

Example
```js
const chat = require('skygear-chat');
chat.cloud.afterMessageSent((message, conversation, participants, context) => {
  //blah blah blah
});
```
Connects SkygearIO/guides#166