### PR TITLE
Fix cloud function import problem

### DIFF
--- a/cloud.js
+++ b/cloud.js
@@ -1,0 +1,1 @@
+module.exports = require('skygear-chat/dist/cloud.js');

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/SkygearIO/chat-SDK-JS#readme",
   "author": "Rick Mak",
   "files": [
+    "cloud.js",
     "dist"
   ],
   "main": "dist/index.js",


### PR DESCRIPTION
- cloud can be imported by `const cloud = require('skygear-chat/cloud');`

Example:
```js
const chatCloud = require('skygear-chat/cloud');
chatCloud.afterMessageSent((message, conversation, participants, context) => {
  //blah blah blah
});
```
Connects SkygearIO/guides#166