### PR TITLE
Revert the re-export `cloud` at index

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,6 @@
 import skygearChat from './container.js';
-import cloud from './cloud.js';
 import * as utils from './utils.js';
 
 skygearChat.utils = utils;
-skygearChat.cloud = cloud;
 
 module.exports = skygearChat;


### PR DESCRIPTION
Index is expected to only using in front-end browser, the `cloud` will
only use in cloud code (node) environment.

refs SkygearIO/guides#166